### PR TITLE
Исправлен баг при сравнении парных тэгов

### DIFF
--- a/lib/openxml_docx_templater/docx_eruby.rb
+++ b/lib/openxml_docx_templater/docx_eruby.rb
@@ -84,7 +84,7 @@ module OpenxmlDocxTemplater
       open = open.to_s.strip
       close = close.to_s.strip
 
-      close == "</#{open[1, close.length - 3]}>"
+      close == "</#{open[1, close.length - 1]}>"
     end
   end
 end


### PR DESCRIPTION
При обработке контрольных строк типа {%...%}, вокруг них исключались парные тэги.
Сравнение проводилось по первым двум символам "w:", в следствии чего при стечении некоторых обстоятельств, например, в промежутке между нужными открывающим и закрывающим тэгом попадался дополнительный параметр с открывающим/закрывающим тэгом, исключались неверные пары.
Изменил параметры сравнения, теперь сравнение тэгов производится по полному основанию закрывающего тэга.
  